### PR TITLE
opengate: gate canvas hook on selector r5==175 (stop corrupting other CinemaDNG framerates)

### DIFF
--- a/opengate/GATED-FIX.md
+++ b/opengate/GATED-FIX.md
@@ -1,0 +1,50 @@
+# Open-gate mode isolation fix (gated rowpatch)
+
+## Problem
+The open-gate test build repurposes the FHD/29.97 CinemaDNG preset and arms a
+FieldAngle canvas hook at `0xC043A19C` whose payload (`rowpatch_v4.S`) decides
+whether to rewrite geometry **using the row dimensions only** (1936x1090). But
+other CinemaDNG framerates on the same FHD family (e.g. FHD/25) also build a
+1936x1090 FieldAngle row, so the hook fires for them too and stretches them to
+3032x2012 against a sensor that is not mode 117 — corrupting those modes
+(purple lines / small offset frame / white).
+
+## Root cause (measured on hardware, fp Ver.5.02, over the USB shell)
+The FieldAngle build function `0xC043A158` receives a **selector r5** and maps it
+through the profile table `0xC0BD05D4` (`table[r5]` = profile index). Measured
+selector values while the hook fired:
+
+| preset (CinemaDNG) | selector r5 | builds 1936x1090 row |
+|---|---|---|
+| FHD/29.97 (open gate, mode 117) | **175 (0xAF)** | yes |
+| FHD/25 | 180 (0xB4) | yes |
+
+r5 is passed straight into the hook, so it is correct at hook time (unlike the
+selected-mode register `0xC343B590`, which is only 117 mid-take — gating on it
+made the hook never fire and broke open gate itself). During a real open-gate
+take the hook fired 474x in ~3 s, r5 == 175 every time (stable standby + record).
+
+## Fix
+`rowpatch_gated.S` adds two gates to `rowpatch_v4`'s logic:
+1. an `ARMED` flag word at `0xC072FA10` (lets a controller enable/disable without
+   unhooking), and
+2. **`r5 == 175`** — the open-gate selector — before the dimension check.
+
+So the canvas rewrite happens only for the actual open-gate take; every other
+framerate/mode falls through as a byte-for-byte no-op and records as stock.
+Verified: on hardware, open gate still records 3032x2012 while FHD/25 and the
+other modes record cleanly; in an ARM emulator all gate paths pass (rewrite only
+for armed + 1936x1090 + r5==175).
+
+## Build
+`build_gated_autorun.py` reuses `build_test_autorun.py`'s verified helpers/data
+patches and emits an AutoRun with the gated payload at `0xC072F800`, the ARMED
+flag at `0xC072FA10`, and the hook armed last (banner `fpOGgate!`):
+
+    ./build_gated_autorun.py --firmware /path/to/MAIN_c0000000.bin
+
+RAM-only, reverts on power-off (battery out), same as the test build.
+
+## Files
+- `rowpatch_gated.S` — the r5-gated canvas hook.
+- `build_gated_autorun.py` — builder (mirrors build_test_autorun.py).

--- a/opengate/build_gated_autorun.py
+++ b/opengate/build_gated_autorun.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Build a mode-gated open-gate AutoRun that does NOT corrupt other modes.
+
+Same data patches as build_test_autorun.py (picker slot 7, mode-117 VMAX, the
+four FHD/29.97 RWZM cells), but the live FieldAngle canvas hook is replaced with
+rowpatch_gated.S, which additionally requires the FieldAngle build **selector r5
+== 175** before it rewrites geometry. r5 was measured on hardware (SIGMA fp
+Ver.5.02, over the USB shell): 175 for FHD/29.97 CinemaDNG (open gate) and 180
+for FHD/25, both of which build a 1936x1090 row — so the stock rowpatch_v4
+(dimensions-only) also fired for FHD/25 and stretched it, corrupting it. Gating
+on r5 fixes that: other framerates/modes fall through as a no-op.
+
+Reuses build_test_autorun.py's verified helpers; emits AutoRun.txt with the
+gated payload at 0xC072F800, an ARMED flag at 0xC072FA10, and the hook armed last.
+
+  ./build_gated_autorun.py --firmware /path/to/MAIN_c0000000.bin
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import struct
+import subprocess
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO = HERE.parent
+SHELL_DIR = REPO / "fp_usb_shell"
+SOURCE = HERE / "rowpatch_gated.S"
+sys.path.insert(0, str(SHELL_DIR))
+sys.path.insert(0, str(HERE))
+from armasm import assemble, words  # noqa: E402
+import build_test_autorun as og  # noqa: E402
+
+CODE = 0xC072F800
+LOG = 0xC072FA00
+ARMED = 0xC072FA10
+HOOK = 0xC043A19C
+HOOK_STOCK = 0xE1A00004
+HOOK_BRANCH = 0xEB000000 | ((((CODE - HOOK - 8) >> 2) & 0xFFFFFF))
+BANNER = "fpOGgate!"
+FIRMWARE_BASE = 0xC0000000
+
+
+def firmware_word(image, address):
+    return struct.unpack_from("<I", image, address - FIRMWARE_BASE)[0]
+
+
+def verify_firmware(path, blob):
+    image = path.read_bytes()
+    if (len(image) != og.FIRMWARE_BYTES
+            or hashlib.sha256(image).hexdigest() != og.FIRMWARE_SHA256):
+        raise SystemExit("reference firmware is not the verified fp Ver.5.02 image")
+    for address, stock, _, _ in og.DATA_PATCHES:
+        if firmware_word(image, address) != stock:
+            raise SystemExit(f"stock mismatch at 0x{address:08X}")
+    if firmware_word(image, HOOK) != HOOK_STOCK:
+        raise SystemExit("hook site is not the stock mov r0,r4")
+    if any(image[CODE - FIRMWARE_BASE: ARMED + 4 - FIRMWARE_BASE]):
+        raise SystemExit("cave 0xC072F800..0xC072FA14 is not empty in firmware")
+    if CODE + len(blob) > LOG:
+        raise SystemExit("gated payload overlaps the telemetry log")
+
+
+def gated_section(blob):
+    lines = [
+        "# --- MODE-GATED 3032x2012 open gate @29.97 -------------------------",
+        "# fp Ver.5.02 ONLY. Cold-boot RAM patches; remove AutoRun.txt and",
+        "# power-cycle (battery out) to return to stock. Hook no-ops unless the",
+        "# FieldAngle selector r5 == 175, so other framerates/modes are untouched.",
+        "",
+    ]
+    for address, stock, value, comment in og.DATA_PATCHES:
+        lines.append(f"# {comment}; stock 0x{stock:08X}")
+        lines.append(f"mem set 0x{address:08X} 0x{value:08X}")
+    lines += ["", f"# clear telemetry words at 0x{LOG:08X}"]
+    for offset in range(0, 0x10, 4):
+        lines.append(f"mem set 0x{LOG + offset:08X} 0x00000000")
+    lines += ["", "# arm the feature (controller flag)",
+              f"mem set 0x{ARMED:08X} 0x00000001"]
+    lines += ["", f"# mode-gated rowpatch, {len(blob)} bytes"]
+    for index, value in enumerate(words(blob)):
+        lines.append(f"mem set 0x{CODE + index * 4:08X} 0x{value:08X}")
+    lines += [
+        "",
+        "# Arm last: stock instruction is 0xE1A00004 (mov r0,r4).",
+        f"mem set 0x{HOOK:08X} 0x{HOOK_BRANCH:08X}",
+        "# --- END gated open gate --------------------------------------------",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--firmware", type=pathlib.Path, default=og.DEFAULT_FIRMWARE)
+    parser.add_argument("--out", type=pathlib.Path, default=HERE / "AutoRun.gated.txt")
+    args = parser.parse_args()
+    blob = assemble(SOURCE)
+    if words(blob)[-2:] != (0xE1A00004, 0xE12FFF1E):
+        raise SystemExit("payload must end with the displaced mov and bx lr")
+    verify_firmware(args.firmware, blob)
+    with tempfile.TemporaryDirectory() as tmp:
+        base_path = pathlib.Path(tmp) / "AutoRun.base.txt"
+        result = subprocess.run(
+            (sys.executable, str(SHELL_DIR / "build_autorun.py"), "--out", str(base_path),
+             "--banner", BANNER, "--no-ep-patches", "--no-pad"), check=False)
+        if result.returncode:
+            raise SystemExit("canonical shell builder failed")
+        base = og.describe_minimal_usb_shell(base_path.read_text(encoding="utf-8"))
+    section = gated_section(blob)
+    output = og.insert_before_done(base, section)
+    if og.parse_mem_sets(output)[-1] != (HOOK, HOOK_BRANCH):
+        raise SystemExit("hook must be the final mem set")
+    output_bytes = og.pad_bytes(output)
+    args.out.write_bytes(output_bytes)
+    print(f"built {args.out} ({len(output_bytes)} bytes)  sha256 {hashlib.sha256(output_bytes).hexdigest()}")
+    print(f"payload {len(blob)} bytes at 0x{CODE:08X}; ARMED 0x{ARMED:08X}; hook 0x{HOOK_BRANCH:08X}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/opengate/rowpatch_gated.S
+++ b/opengate/rowpatch_gated.S
@@ -1,0 +1,108 @@
+.syntax unified
+.arm
+.text
+
+/*
+ * Mode-gated 3032x2012 canvas hook -- isolation-safe successor to rowpatch_v4.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * rowpatch_v4 gates ONLY on the geometry row being 1936x1090, so it also fires
+ * for other FHD CinemaDNG framerates (e.g. FHD/25) that build the same row and
+ * stretches them to 3032x2012 against a sensor that is not the open-gate mode --
+ * the corruption of those modes.
+ *
+ * THE GATE, MEASURED ON HARDWARE (SIGMA fp Ver.5.02, 2026-09-10, USB shell):
+ *   The FieldAngle build selector r5 is 175 for FHD/29.97 CinemaDNG (open gate)
+ *   and 180 for FHD/25 CinemaDNG. Verified stable across standby AND an actual
+ *   take: the hook fired 474x during a ~3s open-gate record, r5 == 175 every
+ *   time. r5 is passed straight into the hook so it is correct at hook time --
+ *   unlike 0xC343B590, which only becomes 117 mid-take and made the hook never
+ *   fire (that was the bug that broke open gate).
+ *
+ * So: rewrite only when armed AND the row is 1936x1090 AND r5 == 175. Every
+ * other framerate/mode falls through as a no-op and records exactly as stock.
+ *
+ * ABI (unchanged from v4):
+ *   r4 = FieldAngle object, r4+0x5C = geometry row, r5 = selector.
+ *   Hook site 0xC043A19C uses BL; displaced instruction is `mov r0,r4`.
+ *   Returns through LR after replaying it.
+ */
+
+.equ LOG,            0xC072FA00     /* telemetry: [0]=hits [4]=selector [8..]=orig */
+.equ ROW,            0x5C
+.equ SEL_OPENGATE,   175            /* measured FHD/29.97 CinemaDNG selector (0xAF) */
+.equ ARMED,          0xC072FA10     /* controller flag: nonzero = feature on */
+
+.macro LDA reg, value
+    movw    \reg, #:lower16:\value
+    movt    \reg, #:upper16:\value
+.endm
+
+.macro PUT off, val
+    movw    r3, #\val
+    movw    r0, #\off
+    str     r3, [r1, r0]
+.endm
+
+.global entry
+entry:
+    push    {r0, r1, r2, r3, ip, lr}
+    add     r1, r4, #ROW
+    LDA     ip, LOG
+
+    /* Gate 1: controller must have the feature armed. */
+    LDA     r0, ARMED
+    ldr     r0, [r0]
+    cmp     r0, #0
+    beq     out
+
+    /* Gate 2: the shipping FHD CinemaDNG row only. */
+    ldr     r3, [r1]
+    movw    r0, #1936
+    cmp     r3, r0
+    bne     out
+    ldr     r3, [r1, #4]
+    movw    r0, #1090
+    cmp     r3, r0
+    bne     out
+
+    /* Gate 3 (the isolation fix): open-gate selector only. Measured on hardware:
+     * 175 = FHD/29.97 CinemaDNG (open gate), 180 = FHD/25. Any other framerate
+     * that builds a 1936x1090 row falls through untouched and records as stock. */
+    movw    r0, #SEL_OPENGATE
+    cmp     r5, r0
+    bne     out
+
+    /* Preserve the first pre-overwrite producer fields for diagnosis. */
+    ldr     r0, [ip]
+    cmp     r0, #0
+    bne     patch
+    str     r5, [ip, #4]
+    movw    r0, #0x0D8
+    ldr     r3, [r1, r0]
+    str     r3, [ip, #8]
+    movw    r0, #0x0E0
+    ldr     r3, [r1, r0]
+    str     r3, [ip, #12]
+
+patch:
+    PUT     0x000, 3032       /* base */
+    PUT     0x004, 2012
+    PUT     0x024, 3008       /* active; yields crop origin (12,6) */
+    PUT     0x02C, 2000
+    PUT     0x0D8, 3032       /* producer-side width/height pair */
+    PUT     0x0E0, 2012
+    PUT     0x0DC, 3032       /* size-getter override */
+    PUT     0x0E4, 2012
+    PUT     0x0F4, 3032       /* input */
+    PUT     0x0F8, 2012
+
+    ldr     r3, [ip]
+    add     r3, r3, #1
+    str     r3, [ip]
+
+out:
+    pop     {r0, r1, r2, r3, ip, lr}
+    mov     r0, r4
+    bx      lr


### PR DESCRIPTION
The open-gate test's canvas hook (rowpatch_v4 at 0xC043A19C) gates on row dimensions only (1936x1090). Other FHD CinemaDNG framerates (e.g. FHD/25) build the same 1936x1090 row, so the hook mis-fires and stretches them -> corruption of those modes.

Measured on hardware (fp Ver.5.02, USB shell): the FieldAngle build selector r5 is **175** for FHD/29.97 (open gate, mode 117) and **180** for FHD/25 (both build 1936x1090). r5 is passed into the hook so it is valid at hook time (the selected-mode reg 0xC343B590 is only 117 mid-take, so gating on it breaks open gate instead).

**rowpatch_gated.S** adds an ARMED flag (0xC072FA10) + an **r5==175** gate before the dimension check, so the rewrite only happens for the real open-gate take; every other mode no-ops and records stock. Verified on hardware (open gate still 3032x2012, FHD/25 clean) and in an ARM emulator (all gate paths). build_gated_autorun.py mirrors build_test_autorun.py. Full writeup in opengate/GATED-FIX.md. RAM-only, reverts on power-off.

Found while collaborating on fp mods; happy to adjust to your conventions.